### PR TITLE
[Feature/25] 공부 분류 등록 API 및 에러 처리 추가

### DIFF
--- a/src/main/java/timify/com/auth/AuthController.java
+++ b/src/main/java/timify/com/auth/AuthController.java
@@ -1,5 +1,7 @@
 package timify.com.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,17 +17,20 @@ import timify.com.common.apiPayload.code.status.SuccessStatus;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/login")
+    @Operation(summary = "로그인 API", description = "로그인 API 입니다.")
     public ApiResponse<AuthResponse.loginDto> login(@RequestBody AuthRequest.loginRequest request) {
 
         return ApiResponse.onSuccess(authService.login(request.getId(), request.getLoginType()));
     }
 
     @PostMapping("/reissue")
+    @Operation(summary = "jwt 토큰 재발급 API", description = "access token, refresh token을 재발급 받는 API 입니다.")
     public ApiResponse<AuthResponse.reissueDto> reissueToken(@RequestBody AuthRequest.reissueRequest request) {
 
         return ApiResponse.of(SuccessStatus.TOKEN_REISSUE_SUCCESS, authService.reissueToken(request));

--- a/src/main/java/timify/com/auth/AuthService.java
+++ b/src/main/java/timify/com/auth/AuthService.java
@@ -12,9 +12,9 @@ import timify.com.auth.jwt.RefreshTokenService;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.exception.handler.AuthHandler;
 import timify.com.common.apiPayload.exception.handler.MemberHandler;
-import timify.com.member.MemberRepository;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
+import timify.com.member.repository.MemberRepository;
 
 @Slf4j
 @Service

--- a/src/main/java/timify/com/auth/jwt/RefreshTokenService.java
+++ b/src/main/java/timify/com/auth/jwt/RefreshTokenService.java
@@ -7,9 +7,9 @@ import timify.com.auth.dto.AuthRequest;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.exception.handler.AuthHandler;
 import timify.com.common.apiPayload.exception.handler.MemberHandler;
-import timify.com.member.MemberRepository;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
+import timify.com.member.repository.MemberRepository;
 
 import java.util.UUID;
 

--- a/src/main/java/timify/com/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/timify/com/auth/security/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByMemberIdAndSocialId(Long memberId, Long socialId) throws UsernameNotFoundException {
         Member member = memberRepository.findByIdAndSocialId(memberId, socialId)
                 .orElseThrow(() -> new JwtAuthenticationException(ErrorStatus.MEMBER_NOT_FOUND));
-        if (member.getStatus().equals(MemberStatus.INACTIVE)) {
+        if (member.getStatus().equals(MemberStatus.INACTIVE)) { // 탈퇴한 회원인 경우 에러 발생
             throw new JwtAuthenticationException(ErrorStatus.INACTIVE_MEMBER);
         }
         return new CustomUserDetails(member.getId(), member.getSocialId(), member.getLoginType(), member.getRoleType());

--- a/src/main/java/timify/com/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/timify/com/auth/security/CustomUserDetailsService.java
@@ -7,9 +7,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
-import timify.com.common.apiPayload.exception.handler.MemberHandler;
-import timify.com.member.MemberRepository;
+import timify.com.common.apiPayload.exception.JwtAuthenticationException;
 import timify.com.member.domain.Member;
+import timify.com.member.domain.MemberStatus;
+import timify.com.member.repository.MemberRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,8 +20,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     public UserDetails loadUserByMemberIdAndSocialId(Long memberId, Long socialId) throws UsernameNotFoundException {
         Member member = memberRepository.findByIdAndSocialId(memberId, socialId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
+                .orElseThrow(() -> new JwtAuthenticationException(ErrorStatus.MEMBER_NOT_FOUND));
+        if (member.getStatus().equals(MemberStatus.INACTIVE)) {
+            throw new JwtAuthenticationException(ErrorStatus.INACTIVE_MEMBER);
+        }
         return new CustomUserDetails(member.getId(), member.getSocialId(), member.getLoginType(), member.getRoleType());
     }
 

--- a/src/main/java/timify/com/auth/security/SecurityConfig.java
+++ b/src/main/java/timify/com/auth/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                                 exceptionHandling
                                         .accessDeniedHandler(accessDeniedHandler) // access deny 되었을 때 커스텀 응답 주기 위한 커스텀 handler
                                         .authenticationEntryPoint(unauthorizedHandler)) // 로그인되지 않은 요청에 대해 커스텀 응답 주기 위한 커스텀 handler
-                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter에서 회원에 대한 탈퇴 여부 검증 진행
                 .addFilterBefore(jwtAuthenticationExceptionHandler, JwtAuthFilter.class);
 
 

--- a/src/main/java/timify/com/auth/security/SecurityUtil.java
+++ b/src/main/java/timify/com/auth/security/SecurityUtil.java
@@ -1,0 +1,20 @@
+package timify.com.auth.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import timify.com.common.apiPayload.code.status.ErrorStatus;
+import timify.com.common.apiPayload.exception.handler.AuthHandler;
+
+public class SecurityUtil {
+
+    public static Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getMemberId();
+        } else {
+            throw new AuthHandler(ErrorStatus.UNAUTHORIZED_EXCEPTION);
+        }
+
+    }
+}

--- a/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
@@ -28,7 +28,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회원 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "사용자를 찾을 수 없습니다."),
-    MEMBER_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 가입된 사용자 입니다.");
+    MEMBER_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 가입된 사용자 입니다."),
+
+    // 공부 분류, 방법, 장소 관련 에러
+    STUDY_TYPE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4001", "이미 존재하는 공부 분류 이름 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
@@ -22,8 +22,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_LOGINTYPE(HttpStatus.BAD_REQUEST, "AUTH4001", "유효하지 않은 로그인 타입입니다."),
     INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH4002", "토큰이 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4003", "리프레쉬 토큰이 유효하지 않습니다. 다시 로그인 해주세요"),
-    EXPIRED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH004", "기존 토큰이 만료되었습니다. 토큰을 재발급해주세요."),
-    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH005", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
+    EXPIRED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH4004", "기존 토큰이 만료되었습니다. 토큰을 재발급해주세요."),
+    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "AUTH4005", "로그인 후 이용가능합니다. 토큰을 입력해 주세요"),
+    INACTIVE_MEMBER(HttpStatus.NOT_FOUND, "AUTH4006", "탈퇴한 사용자 입니다."),
 
 
     // 회원 관련 에러

--- a/src/main/java/timify/com/domain/MemberMission.java
+++ b/src/main/java/timify/com/domain/MemberMission.java
@@ -17,10 +17,10 @@ public class MemberMission extends BaseDateTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mission_id")
+    @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
 }

--- a/src/main/java/timify/com/domain/Notice.java
+++ b/src/main/java/timify/com/domain/Notice.java
@@ -15,5 +15,10 @@ public class Notice extends BaseDateTimeEntity {
     @Column(name = "notice_id")
     private Long id;
 
-    
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(nullable = false, length = 5000)
+    private String contents;
+
 }

--- a/src/main/java/timify/com/domain/StudyMethod.java
+++ b/src/main/java/timify/com/domain/StudyMethod.java
@@ -28,6 +28,6 @@ public class StudyMethod extends BaseDateTimeEntity {
     private CategoryStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 }

--- a/src/main/java/timify/com/domain/StudyPlace.java
+++ b/src/main/java/timify/com/domain/StudyPlace.java
@@ -28,6 +28,6 @@ public class StudyPlace extends BaseDateTimeEntity {
     private CategoryStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 }

--- a/src/main/java/timify/com/domain/StudyTime.java
+++ b/src/main/java/timify/com/domain/StudyTime.java
@@ -31,14 +31,14 @@ public class StudyTime extends BaseDateTimeEntity {
     private Double temp;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "subject_id")
+    @JoinColumn(name = "subject_id", nullable = false)
     private Subject subject;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "todo_id")
+    @JoinColumn(name = "todo_id", nullable = false)
     private Todo todo;
 }

--- a/src/main/java/timify/com/domain/StudyType.java
+++ b/src/main/java/timify/com/domain/StudyType.java
@@ -28,7 +28,7 @@ public class StudyType extends BaseDateTimeEntity {
     private CategoryStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
 }

--- a/src/main/java/timify/com/domain/StudyType.java
+++ b/src/main/java/timify/com/domain/StudyType.java
@@ -31,4 +31,13 @@ public class StudyType extends BaseDateTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    // 연관관계 메소드
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getStudyTypeList().remove(this);
+        }
+        this.member = member;
+        this.member.getStudyTypeList().add(this);
+    }
+
 }

--- a/src/main/java/timify/com/domain/Subject.java
+++ b/src/main/java/timify/com/domain/Subject.java
@@ -31,7 +31,7 @@ public class Subject extends BaseDateTimeEntity {
     private SubjectStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     // todo 양방향 매핑

--- a/src/main/java/timify/com/domain/Todo.java
+++ b/src/main/java/timify/com/domain/Todo.java
@@ -32,23 +32,23 @@ public class Todo extends BaseDateTimeEntity {
     private TodoStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "subject_id")
+    @JoinColumn(name = "subject_id", nullable = false)
     private Subject subject;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_type_id")
+    @JoinColumn(name = "study_type_id", nullable = false)
     private StudyType studyType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_method_id")
+    @JoinColumn(name = "study_method_id", nullable = false)
     private StudyMethod studyMethod;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_place_id")
+    @JoinColumn(name = "study_place_id", nullable = false)
     private StudyPlace studyPlace;
 
     // studyTime 양방향 매핑

--- a/src/main/java/timify/com/member/MemberController.java
+++ b/src/main/java/timify/com/member/MemberController.java
@@ -1,10 +1,13 @@
 package timify.com.member;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import timify.com.auth.AuthService;
 import timify.com.auth.dto.AuthResponse;
@@ -15,20 +18,22 @@ import timify.com.domain.StudyType;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.dto.MemberResponse;
-import timify.com.member.repository.MemberRepository;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1/member")
-@Validated
+@Tag(name = "Member", description = "Member 관련 API")
 public class MemberController {
 
     private final AuthService authService;
     private final MemberService memberService;
-    private final MemberRepository memberRepository;
 
     @PostMapping("/signin/{loginType}")
+    @Operation(summary = "회원가입 API", description = "소셜 계정 기반 회원 가입 API 입니다.")
+    @Parameters(value = {
+            @Parameter(name = "loginType", description = "소셜 로그인 타입으로, KAKAO 또는 APPLE을 입력해야 합니다.")
+    })
     public ApiResponse<AuthResponse.loginDto> signin(@RequestBody @Valid MemberRequest.signinRequest request,
                                                      @PathVariable(name = "loginType") String loginType
     ) {
@@ -39,6 +44,7 @@ public class MemberController {
     }
 
     @GetMapping("/test")
+    @Operation(summary = "테스트용 회원 정보 조회 API", description = "jwt 테스트용, 로그인한 회원 정보를 조회하는 API 입니다.")
     public ApiResponse<MemberResponse.myInfoDto> getMyInfo(Authentication authentication) {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
 
@@ -56,6 +62,7 @@ public class MemberController {
     }
 
     @PostMapping("/study/type/insert")
+    @Operation(summary = "공부 분류 등록 API", description = "공부 분류를 추가하는 API 입니다.")
     public ApiResponse<MemberResponse.studyTypeInsertDto> insertStudyType(@RequestBody @Valid MemberRequest.studyTypeInsertRequest request) {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
 

--- a/src/main/java/timify/com/member/MemberController.java
+++ b/src/main/java/timify/com/member/MemberController.java
@@ -8,12 +8,9 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import timify.com.auth.AuthService;
 import timify.com.auth.dto.AuthResponse;
-import timify.com.auth.security.CustomUserDetails;
 import timify.com.auth.security.SecurityUtil;
 import timify.com.common.apiPayload.ApiResponse;
-import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.code.status.SuccessStatus;
-import timify.com.common.apiPayload.exception.handler.MemberHandler;
 import timify.com.domain.StudyType;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
@@ -43,9 +40,7 @@ public class MemberController {
 
     @GetMapping("/test")
     public ApiResponse<MemberResponse.myInfoDto> getMyInfo(Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        Long memberId = userDetails.getMemberId();
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
 
         MemberResponse.myInfoDto response = MemberResponse.myInfoDto.builder()
                 .socialId(member.getSocialId())
@@ -62,8 +57,7 @@ public class MemberController {
 
     @PostMapping("/study/type/insert")
     public ApiResponse<MemberResponse.studyTypeInsertDto> insertStudyType(@RequestBody @Valid MemberRequest.studyTypeInsertRequest request) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
-        Member member = memberService.findActiveMember(memberId);
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
 
         StudyType studyType = memberService.insertStudyType(request, member);
 

--- a/src/main/java/timify/com/member/MemberController.java
+++ b/src/main/java/timify/com/member/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import timify.com.auth.AuthService;
 import timify.com.auth.dto.AuthResponse;
 import timify.com.auth.security.CustomUserDetails;
+import timify.com.auth.security.SecurityUtil;
 import timify.com.common.apiPayload.ApiResponse;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.code.status.SuccessStatus;
@@ -14,6 +15,7 @@ import timify.com.common.apiPayload.exception.handler.MemberHandler;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.dto.MemberResponse;
+import timify.com.member.repository.MemberRepository;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,5 +54,17 @@ public class MemberController {
                 .build();
 
         return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping("/study/type/insert")
+    public ApiResponse<MemberResponse.studyTypeInsertDto> insertStudyType(@RequestBody MemberRequest.studyTypeInsertRequest request,
+                                                                          Authentication authentication) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+
+        return null;
+
+
     }
 }

--- a/src/main/java/timify/com/member/MemberConverter.java
+++ b/src/main/java/timify/com/member/MemberConverter.java
@@ -1,7 +1,10 @@
 package timify.com.member;
 
+import timify.com.domain.StudyType;
+import timify.com.domain.enums.CategoryStatus;
 import timify.com.member.domain.*;
 import timify.com.member.dto.MemberRequest;
+import timify.com.member.dto.MemberResponse;
 
 public class MemberConverter {
 
@@ -23,6 +26,21 @@ public class MemberConverter {
                 .socialId(request.getSocialId())
                 .loginType(loginType)
                 .status(MemberStatus.ACTIVE)
+                .build();
+    }
+
+    public static StudyType toStudyType(String title, int order) {
+        return StudyType.builder()
+                .title(title)
+                .order_num(order)
+                .status(CategoryStatus.ACTIVE)
+                .build();
+    }
+
+    public static MemberResponse.studyTypeInsertDto toStudyTypeInsertDto(StudyType studyType) {
+        return MemberResponse.studyTypeInsertDto.builder()
+                .studyTypeId(studyType.getId())
+                .studyTypeTitle(studyType.getTitle())
                 .build();
     }
 }

--- a/src/main/java/timify/com/member/MemberService.java
+++ b/src/main/java/timify/com/member/MemberService.java
@@ -5,9 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.exception.handler.MemberHandler;
+import timify.com.domain.StudyType;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
+import timify.com.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -34,4 +36,14 @@ public class MemberService {
         return memberRepository.save(member);
 
     }
+
+    @Transactional
+    public StudyType insertStudyType(MemberRequest.studyTypeInsertRequest request, Member member) {
+        // 이미 존재하는 이름의 StudyType인지 검증
+
+
+        return null;
+    }
+
+
 }

--- a/src/main/java/timify/com/member/MemberService.java
+++ b/src/main/java/timify/com/member/MemberService.java
@@ -8,7 +8,6 @@ import timify.com.common.apiPayload.exception.handler.MemberHandler;
 import timify.com.domain.StudyType;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
-import timify.com.member.domain.MemberStatus;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.repository.MemberRepository;
 import timify.com.member.repository.StudyTypeRepository;
@@ -57,12 +56,8 @@ public class MemberService {
         return studyTypeRepository.save(studyType);
     }
 
-    public Member findActiveMember(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        if (member.getStatus().equals(MemberStatus.INACTIVE)) {
-            throw new MemberHandler(ErrorStatus.INACTIVE_MEMBER);
-        }
-        return member;
+    public Member findMember(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
 

--- a/src/main/java/timify/com/member/MemberService.java
+++ b/src/main/java/timify/com/member/MemberService.java
@@ -8,14 +8,17 @@ import timify.com.common.apiPayload.exception.handler.MemberHandler;
 import timify.com.domain.StudyType;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
+import timify.com.member.domain.MemberStatus;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.repository.MemberRepository;
+import timify.com.member.repository.StudyTypeRepository;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final StudyTypeRepository studyTypeRepository;
 
     @Transactional
     public Member join(MemberRequest.signinRequest request, String reqLoginType) {
@@ -40,9 +43,26 @@ public class MemberService {
     @Transactional
     public StudyType insertStudyType(MemberRequest.studyTypeInsertRequest request, Member member) {
         // 이미 존재하는 이름의 StudyType인지 검증
+        boolean exists = member.getStudyTypeList().stream()
+                .anyMatch(studyType -> request.getTitle().equals(studyType.getTitle()));
 
+        if (exists) {
+            throw new MemberHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
+        }
 
-        return null;
+        // StudyType 엔티티 생성 및 연관관계 매핑
+        StudyType studyType = MemberConverter.toStudyType(request.getTitle(), member.getStudyTypeList().size() + 1);
+        studyType.setMember(member);
+
+        return studyTypeRepository.save(studyType);
+    }
+
+    public Member findActiveMember(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (member.getStatus().equals(MemberStatus.INACTIVE)) {
+            throw new MemberHandler(ErrorStatus.INACTIVE_MEMBER);
+        }
+        return member;
     }
 
 

--- a/src/main/java/timify/com/member/dto/MemberRequest.java
+++ b/src/main/java/timify/com/member/dto/MemberRequest.java
@@ -21,4 +21,9 @@ public class MemberRequest {
 
         String loginType;
     }
+
+    @Getter
+    public static class studyTypeInsertRequest {
+        String title;
+    }
 }

--- a/src/main/java/timify/com/member/dto/MemberRequest.java
+++ b/src/main/java/timify/com/member/dto/MemberRequest.java
@@ -1,5 +1,8 @@
 package timify.com.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -7,23 +10,32 @@ import java.time.LocalDate;
 public class MemberRequest {
     @Getter
     public static class signinRequest {
+        @NotBlank
         String email;
 
+        @NotBlank
         String name;
 
+        @NotBlank
         String gender;
 
+        @NotBlank
         String job;
 
+        @NotNull
         LocalDate birth;
 
+        @NotNull
         Long socialId;
 
+        @NotBlank
         String loginType;
     }
 
     @Getter
     public static class studyTypeInsertRequest {
+        @NotBlank
+        @Size(max = 30)
         String title;
     }
 }

--- a/src/main/java/timify/com/member/dto/MemberResponse.java
+++ b/src/main/java/timify/com/member/dto/MemberResponse.java
@@ -31,6 +31,7 @@ public class MemberResponse {
     @AllArgsConstructor
     public static class studyTypeInsertDto {
         Long studyTypeId;
+        String studyTypeTitle;
     }
 
 }

--- a/src/main/java/timify/com/member/dto/MemberResponse.java
+++ b/src/main/java/timify/com/member/dto/MemberResponse.java
@@ -24,4 +24,13 @@ public class MemberResponse {
         Gender gender;
         LocalDate birth;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class studyTypeInsertDto {
+        Long studyTypeId;
+    }
+
 }

--- a/src/main/java/timify/com/member/repository/MemberRepository.java
+++ b/src/main/java/timify/com/member/repository/MemberRepository.java
@@ -1,4 +1,4 @@
-package timify.com.member;
+package timify.com.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import timify.com.member.domain.LoginType;
@@ -10,6 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialIdAndLoginType(Long socialId, LoginType loginType);
 
     boolean existsBySocialIdAndLoginType(Long socialId, LoginType loginType);
+
 
     Optional<Member> findByIdAndSocialId(Long memberId, Long socialId);
 }

--- a/src/main/java/timify/com/member/repository/StudyTypeRepository.java
+++ b/src/main/java/timify/com/member/repository/StudyTypeRepository.java
@@ -1,0 +1,10 @@
+package timify.com.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import timify.com.domain.StudyType;
+import timify.com.member.domain.Member;
+
+public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
+
+    boolean existsByMemberAndTitle(Member member, String title);
+}

--- a/src/main/java/timify/com/member/repository/StudyTypeRepository.java
+++ b/src/main/java/timify/com/member/repository/StudyTypeRepository.java
@@ -2,9 +2,6 @@ package timify.com.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import timify.com.domain.StudyType;
-import timify.com.member.domain.Member;
 
 public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
-
-    boolean existsByMemberAndTitle(Member member, String title);
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
공부 분류 (StudyType) 등록 API 구현
공통 에러 처리 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 도메인마다 ManyToOne 연관관계에 nullable=false 설정 추가
- 회원 탈퇴 여부 검증을 UsernamePasswordAuthenticationFilter에서 하도록 에러 처리 추가
- 클라이언트로부터 잘못된 데이터 타입으로 요청 왔을 때의 에러 처리 추가
- request로부터 memberId를 추출하는 SecurityUtil.getCurrentMemberId() 메소드 추가
- 공부 분류 등록 API 구현

## ⏳ 작업 내용
- [x] 공부 분류 등록 API 구현
- [x] 공통 에러 처리 추가
- [x] memberId 추출 메소드 추가
- [x] API Swagger 명세 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
도메인 전반적으로 nullable=false 설정이 추가되어 ddl-auto:create로 실행 한번 필요합니다.
