### PR TITLE
[Feature/27] 공부 분류 조회/수정 API 구현

### DIFF
--- a/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
@@ -32,7 +32,9 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 가입된 사용자 입니다."),
 
     // 공부 분류, 방법, 장소 관련 에러
-    STUDY_TYPE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4001", "이미 존재하는 공부 분류 이름 입니다.");
+    STUDY_TYPE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4001", "이미 존재하는 공부 분류 이름 입니다."),
+    STUDY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4002", "공부 분류를 찾을 수 없습니다."),
+    NOT_STUDY_TYPE_OWNER(HttpStatus.BAD_REQUEST, "STUDY4003", "해당 회원의 공부 분류가 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/timify/com/common/apiPayload/exception/handler/StudyHandler.java
+++ b/src/main/java/timify/com/common/apiPayload/exception/handler/StudyHandler.java
@@ -1,0 +1,10 @@
+package timify.com.common.apiPayload.exception.handler;
+
+import timify.com.common.apiPayload.code.BaseErrorCode;
+import timify.com.common.apiPayload.exception.GeneralException;
+
+public class StudyHandler extends GeneralException {
+    public StudyHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/timify/com/domain/Todo.java
+++ b/src/main/java/timify/com/domain/Todo.java
@@ -5,6 +5,9 @@ import lombok.*;
 import timify.com.domain.common.BaseDateTimeEntity;
 import timify.com.domain.enums.TodoStatus;
 import timify.com.member.domain.Member;
+import timify.com.study.domain.StudyMethod;
+import timify.com.study.domain.StudyPlace;
+import timify.com.study.domain.StudyType;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/timify/com/member/MemberController.java
+++ b/src/main/java/timify/com/member/MemberController.java
@@ -14,7 +14,6 @@ import timify.com.auth.dto.AuthResponse;
 import timify.com.auth.security.SecurityUtil;
 import timify.com.common.apiPayload.ApiResponse;
 import timify.com.common.apiPayload.code.status.SuccessStatus;
-import timify.com.domain.StudyType;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.dto.MemberResponse;
@@ -61,13 +60,5 @@ public class MemberController {
         return ApiResponse.onSuccess(response);
     }
 
-    @PostMapping("/study/type/insert")
-    @Operation(summary = "공부 분류 등록 API", description = "공부 분류를 추가하는 API 입니다.")
-    public ApiResponse<MemberResponse.studyTypeInsertDto> insertStudyType(@RequestBody @Valid MemberRequest.studyTypeInsertRequest request) {
-        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
 
-        StudyType studyType = memberService.insertStudyType(request, member);
-
-        return ApiResponse.onSuccess(MemberConverter.toStudyTypeInsertDto(studyType));
-    }
 }

--- a/src/main/java/timify/com/member/MemberConverter.java
+++ b/src/main/java/timify/com/member/MemberConverter.java
@@ -1,10 +1,7 @@
 package timify.com.member;
 
-import timify.com.domain.StudyType;
-import timify.com.domain.enums.CategoryStatus;
 import timify.com.member.domain.*;
 import timify.com.member.dto.MemberRequest;
-import timify.com.member.dto.MemberResponse;
 
 public class MemberConverter {
 
@@ -29,18 +26,4 @@ public class MemberConverter {
                 .build();
     }
 
-    public static StudyType toStudyType(String title, int order) {
-        return StudyType.builder()
-                .title(title)
-                .order_num(order)
-                .status(CategoryStatus.ACTIVE)
-                .build();
-    }
-
-    public static MemberResponse.studyTypeInsertDto toStudyTypeInsertDto(StudyType studyType) {
-        return MemberResponse.studyTypeInsertDto.builder()
-                .studyTypeId(studyType.getId())
-                .studyTypeTitle(studyType.getTitle())
-                .build();
-    }
 }

--- a/src/main/java/timify/com/member/MemberService.java
+++ b/src/main/java/timify/com/member/MemberService.java
@@ -5,21 +5,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.exception.handler.MemberHandler;
-import timify.com.domain.StudyType;
 import timify.com.member.domain.LoginType;
 import timify.com.member.domain.Member;
 import timify.com.member.dto.MemberRequest;
 import timify.com.member.repository.MemberRepository;
-import timify.com.member.repository.StudyTypeRepository;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final StudyTypeRepository studyTypeRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Member join(MemberRequest.signinRequest request, String reqLoginType) {
         LoginType loginType = null;
         if (reqLoginType.equals(LoginType.KAKAO.toString())) {
@@ -39,23 +36,7 @@ public class MemberService {
 
     }
 
-    @Transactional
-    public StudyType insertStudyType(MemberRequest.studyTypeInsertRequest request, Member member) {
-        // 이미 존재하는 이름의 StudyType인지 검증
-        boolean exists = member.getStudyTypeList().stream()
-                .anyMatch(studyType -> request.getTitle().equals(studyType.getTitle()));
-
-        if (exists) {
-            throw new MemberHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
-        }
-
-        // StudyType 엔티티 생성 및 연관관계 매핑
-        StudyType studyType = MemberConverter.toStudyType(request.getTitle(), member.getStudyTypeList().size() + 1);
-        studyType.setMember(member);
-
-        return studyTypeRepository.save(studyType);
-    }
-
+    @Transactional(readOnly = true)
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }

--- a/src/main/java/timify/com/member/domain/Member.java
+++ b/src/main/java/timify/com/member/domain/Member.java
@@ -2,8 +2,14 @@ package timify.com.member.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import timify.com.domain.*;
+import timify.com.domain.MemberMission;
+import timify.com.domain.StudyTime;
+import timify.com.domain.Subject;
+import timify.com.domain.Todo;
 import timify.com.domain.common.BaseDateTimeEntity;
+import timify.com.study.domain.StudyMethod;
+import timify.com.study.domain.StudyPlace;
+import timify.com.study.domain.StudyType;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/timify/com/member/dto/MemberRequest.java
+++ b/src/main/java/timify/com/member/dto/MemberRequest.java
@@ -2,7 +2,6 @@ package timify.com.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -32,10 +31,5 @@ public class MemberRequest {
         String loginType;
     }
 
-    @Getter
-    public static class studyTypeInsertRequest {
-        @NotBlank
-        @Size(max = 30)
-        String title;
-    }
+
 }

--- a/src/main/java/timify/com/member/dto/MemberResponse.java
+++ b/src/main/java/timify/com/member/dto/MemberResponse.java
@@ -25,13 +25,4 @@ public class MemberResponse {
         LocalDate birth;
     }
 
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class studyTypeInsertDto {
-        Long studyTypeId;
-        String studyTypeTitle;
-    }
-
 }

--- a/src/main/java/timify/com/member/repository/StudyTypeRepository.java
+++ b/src/main/java/timify/com/member/repository/StudyTypeRepository.java
@@ -1,7 +1,0 @@
-package timify.com.member.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import timify.com.study.domain.StudyType;
-
-public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
-}

--- a/src/main/java/timify/com/member/repository/StudyTypeRepository.java
+++ b/src/main/java/timify/com/member/repository/StudyTypeRepository.java
@@ -1,7 +1,7 @@
 package timify.com.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import timify.com.domain.StudyType;
+import timify.com.study.domain.StudyType;
 
 public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
 }

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -39,6 +39,7 @@ public class StudyController {
     }
 
     @GetMapping("/type")
+    @Operation(summary = "공부 분류 조회 API", description = "공부 분류 목록을 조회하는 API 입니다.")
     public ApiResponse<List<StudyResponse.studyTypeDto>> getStudyType() {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
         List<StudyType> studyTypeList = studyService.getStudyTypes(member);

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -14,6 +14,9 @@ import timify.com.study.domain.StudyType;
 import timify.com.study.dto.StudyRequest;
 import timify.com.study.dto.StudyResponse;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -27,18 +30,22 @@ public class StudyController {
 
     @PostMapping("/type/insert")
     @Operation(summary = "공부 분류 등록 API", description = "공부 분류를 추가하는 API 입니다.")
-    public ApiResponse<StudyResponse.studyTypeInsertDto> insertStudyType(@RequestBody @Valid StudyRequest.studyTypeInsertRequest request) {
+    public ApiResponse<StudyResponse.studyTypeDto> insertStudyType(@RequestBody @Valid StudyRequest.studyTypeInsertRequest request) {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
 
         StudyType studyType = studyService.insertStudyType(request, member);
 
-        return ApiResponse.onSuccess(StudyConverter.toStudyTypeInsertDto(studyType));
+        return ApiResponse.onSuccess(StudyConverter.toStudyTypeDto(studyType));
     }
 
     @GetMapping("/type")
-    public ApiResponse<Object> getStudyType() {
+    public ApiResponse<List<StudyResponse.studyTypeDto>> getStudyType() {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+        List<StudyType> studyTypeList = studyService.getStudyTypes(member);
+        List<StudyResponse.studyTypeDto> dtoList = studyTypeList.stream()
+                .map(StudyConverter::toStudyTypeDto)
+                .collect(Collectors.toList());
 
-        return null;
+        return ApiResponse.onSuccess(dtoList);
     }
 }

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -1,0 +1,44 @@
+package timify.com.study;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import timify.com.auth.security.SecurityUtil;
+import timify.com.common.apiPayload.ApiResponse;
+import timify.com.member.MemberService;
+import timify.com.member.domain.Member;
+import timify.com.study.domain.StudyType;
+import timify.com.study.dto.StudyRequest;
+import timify.com.study.dto.StudyResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v1/member/study")
+@Tag(name = "Member", description = "Member 관련 API")
+public class StudyController {
+
+    private final MemberService memberService;
+    private final StudyService studyService;
+
+
+    @PostMapping("/type/insert")
+    @Operation(summary = "공부 분류 등록 API", description = "공부 분류를 추가하는 API 입니다.")
+    public ApiResponse<StudyResponse.studyTypeInsertDto> insertStudyType(@RequestBody @Valid StudyRequest.studyTypeInsertRequest request) {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
+
+        StudyType studyType = studyService.insertStudyType(request, member);
+
+        return ApiResponse.onSuccess(StudyConverter.toStudyTypeInsertDto(studyType));
+    }
+
+    @GetMapping("/type")
+    public ApiResponse<Object> getStudyType() {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+
+        return null;
+    }
+}

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -1,6 +1,8 @@
 package timify.com.study;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +32,7 @@ public class StudyController {
 
     @PostMapping("/type/insert")
     @Operation(summary = "공부 분류 등록 API", description = "공부 분류를 추가하는 API 입니다.")
-    public ApiResponse<StudyResponse.studyTypeDto> insertStudyType(@RequestBody @Valid StudyRequest.studyTypeInsertRequest request) {
+    public ApiResponse<StudyResponse.studyTypeDto> insertStudyType(@RequestBody @Valid StudyRequest.studyTypeRequest request) {
         Member member = memberService.findMember(SecurityUtil.getCurrentMemberId()); // Member의 ACTIVE 여부 검증은 filter에서 이미 진행함
 
         StudyType studyType = studyService.insertStudyType(request, member);
@@ -49,4 +51,20 @@ public class StudyController {
 
         return ApiResponse.onSuccess(dtoList);
     }
+
+    @PostMapping("/type/{studyTypeId}/update")
+    @Operation(summary = "공부 분류 수정 API", description = "특정 공부 분류의 이름을 수정하는 API 입니다.")
+    @Parameters(value = {
+            @Parameter(name = "studyTypeId", description = "공부 분류의 id 입니다.")
+    })
+    public ApiResponse<StudyResponse.studyTypeDto> updateStudyType(
+            @RequestBody @Valid StudyRequest.studyTypeRequest request,
+            @PathVariable(name = "studyTypeId") Long studyTypeId
+    ) {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+        StudyType studyType = studyService.updateStudyType(request, studyTypeId, member);
+
+        return ApiResponse.onSuccess(StudyConverter.toStudyTypeDto(studyType));
+    }
+
 }

--- a/src/main/java/timify/com/study/StudyConverter.java
+++ b/src/main/java/timify/com/study/StudyConverter.java
@@ -1,0 +1,22 @@
+package timify.com.study;
+
+import timify.com.study.domain.CategoryStatus;
+import timify.com.study.domain.StudyType;
+import timify.com.study.dto.StudyResponse;
+
+public class StudyConverter {
+    public static StudyType toStudyType(String title, int order) {
+        return StudyType.builder()
+                .title(title)
+                .order_num(order)
+                .status(CategoryStatus.ACTIVE)
+                .build();
+    }
+
+    public static StudyResponse.studyTypeInsertDto toStudyTypeInsertDto(StudyType studyType) {
+        return StudyResponse.studyTypeInsertDto.builder()
+                .studyTypeId(studyType.getId())
+                .studyTypeTitle(studyType.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/timify/com/study/StudyConverter.java
+++ b/src/main/java/timify/com/study/StudyConverter.java
@@ -13,8 +13,8 @@ public class StudyConverter {
                 .build();
     }
 
-    public static StudyResponse.studyTypeInsertDto toStudyTypeInsertDto(StudyType studyType) {
-        return StudyResponse.studyTypeInsertDto.builder()
+    public static StudyResponse.studyTypeDto toStudyTypeDto(StudyType studyType) {
+        return StudyResponse.studyTypeDto.builder()
                 .studyTypeId(studyType.getId())
                 .studyTypeTitle(studyType.getTitle())
                 .build();

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -1,0 +1,35 @@
+package timify.com.study;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import timify.com.common.apiPayload.code.status.ErrorStatus;
+import timify.com.common.apiPayload.exception.handler.MemberHandler;
+import timify.com.member.domain.Member;
+import timify.com.member.repository.StudyTypeRepository;
+import timify.com.study.domain.StudyType;
+import timify.com.study.dto.StudyRequest;
+
+@Service
+@RequiredArgsConstructor
+public class StudyService {
+
+    private final StudyTypeRepository studyTypeRepository;
+
+    @Transactional
+    public StudyType insertStudyType(StudyRequest.studyTypeInsertRequest request, Member member) {
+        // 이미 존재하는 이름의 StudyType인지 검증
+        boolean exists = member.getStudyTypeList().stream()
+                .anyMatch(studyType -> request.getTitle().equals(studyType.getTitle()));
+
+        if (exists) {
+            throw new MemberHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
+        }
+
+        // StudyType 엔티티 생성 및 연관관계 매핑
+        StudyType studyType = StudyConverter.toStudyType(request.getTitle(), member.getStudyTypeList().size() + 1);
+        studyType.setMember(member);
+
+        return studyTypeRepository.save(studyType);
+    }
+}

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
-import timify.com.common.apiPayload.exception.handler.MemberHandler;
+import timify.com.common.apiPayload.exception.handler.StudyHandler;
 import timify.com.member.domain.Member;
 import timify.com.study.domain.CategoryStatus;
 import timify.com.study.domain.StudyType;
@@ -20,13 +20,13 @@ public class StudyService {
     private final StudyTypeRepository studyTypeRepository;
 
     @Transactional
-    public StudyType insertStudyType(StudyRequest.studyTypeInsertRequest request, Member member) {
+    public StudyType insertStudyType(StudyRequest.studyTypeRequest request, Member member) {
         // 이미 존재하는 이름의 StudyType인지 검증
         boolean exists = member.getStudyTypeList().stream()
                 .anyMatch(studyType -> request.getTitle().equals(studyType.getTitle()));
 
         if (exists) {
-            throw new MemberHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
+            throw new StudyHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
         }
 
         // StudyType 엔티티 생성 및 연관관계 매핑
@@ -40,5 +40,28 @@ public class StudyService {
     public List<StudyType> getStudyTypes(Member member) {
         return studyTypeRepository.findAllByMemberAndStatus(member, CategoryStatus.ACTIVE);
 
+    }
+
+    @Transactional
+    public StudyType updateStudyType(StudyRequest.studyTypeRequest request, Long studyTypeId, Member member) {
+        StudyType studyType = studyTypeRepository.findById(studyTypeId).orElseThrow(() -> new StudyHandler(ErrorStatus.STUDY_TYPE_NOT_FOUND));
+
+        // 해당 studyType이 member의 것이 맞는지 검증
+        if (!studyType.getMember().equals(member)) {
+            throw new StudyHandler(ErrorStatus.NOT_STUDY_TYPE_OWNER);
+        }
+
+        // 활성화된 공부 분류와의 이름 중복 여부 검증
+        boolean exists = member.getStudyTypeList().stream()
+                .anyMatch(type -> request.getTitle().equals(type.getTitle()) && type.getStatus().equals(CategoryStatus.ACTIVE));
+
+        if (exists) {
+            throw new StudyHandler(ErrorStatus.STUDY_TYPE_ALREADY_EXISTS);
+        }
+
+        // studyType의 이름 수정
+        studyType.setTitle(request.getTitle());
+
+        return studyType;
     }
 }

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -6,9 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import timify.com.common.apiPayload.code.status.ErrorStatus;
 import timify.com.common.apiPayload.exception.handler.MemberHandler;
 import timify.com.member.domain.Member;
-import timify.com.member.repository.StudyTypeRepository;
+import timify.com.study.domain.CategoryStatus;
 import timify.com.study.domain.StudyType;
 import timify.com.study.dto.StudyRequest;
+import timify.com.study.repository.StudyTypeRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +34,11 @@ public class StudyService {
         studyType.setMember(member);
 
         return studyTypeRepository.save(studyType);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyType> getStudyTypes(Member member) {
+        return studyTypeRepository.findAllByMemberAndStatus(member, CategoryStatus.ACTIVE);
+
     }
 }

--- a/src/main/java/timify/com/study/domain/CategoryStatus.java
+++ b/src/main/java/timify/com/study/domain/CategoryStatus.java
@@ -1,4 +1,4 @@
-package timify.com.domain.enums;
+package timify.com.study.domain;
 
 public enum CategoryStatus {
     ACTIVE, // 현재 사용중인 공부 분류, 장소, 방법

--- a/src/main/java/timify/com/study/domain/StudyMethod.java
+++ b/src/main/java/timify/com/study/domain/StudyMethod.java
@@ -1,9 +1,8 @@
-package timify.com.domain;
+package timify.com.study.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
 import timify.com.domain.common.BaseDateTimeEntity;
-import timify.com.domain.enums.CategoryStatus;
 import timify.com.member.domain.Member;
 
 @Entity
@@ -11,10 +10,10 @@ import timify.com.member.domain.Member;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class StudyType extends BaseDateTimeEntity {
+public class StudyMethod extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "study_type_id")
+    @Column(name = "study_method_id")
     private Long id;
 
     @Column(nullable = false, length = 30)
@@ -30,14 +29,4 @@ public class StudyType extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-
-    // 연관관계 메소드
-    public void setMember(Member member) {
-        if (this.member != null) {
-            this.member.getStudyTypeList().remove(this);
-        }
-        this.member = member;
-        this.member.getStudyTypeList().add(this);
-    }
-
 }

--- a/src/main/java/timify/com/study/domain/StudyPlace.java
+++ b/src/main/java/timify/com/study/domain/StudyPlace.java
@@ -1,9 +1,8 @@
-package timify.com.domain;
+package timify.com.study.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
 import timify.com.domain.common.BaseDateTimeEntity;
-import timify.com.domain.enums.CategoryStatus;
 import timify.com.member.domain.Member;
 
 @Entity
@@ -11,10 +10,10 @@ import timify.com.member.domain.Member;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class StudyMethod extends BaseDateTimeEntity {
+public class StudyPlace extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "study_method_id")
+    @Column(name = "study_place_id")
     private Long id;
 
     @Column(nullable = false, length = 30)

--- a/src/main/java/timify/com/study/domain/StudyType.java
+++ b/src/main/java/timify/com/study/domain/StudyType.java
@@ -39,4 +39,9 @@ public class StudyType extends BaseDateTimeEntity {
         this.member.getStudyTypeList().add(this);
     }
 
+    // 분류 이름 update를 위한 메소드
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
 }

--- a/src/main/java/timify/com/study/domain/StudyType.java
+++ b/src/main/java/timify/com/study/domain/StudyType.java
@@ -1,9 +1,8 @@
-package timify.com.domain;
+package timify.com.study.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
 import timify.com.domain.common.BaseDateTimeEntity;
-import timify.com.domain.enums.CategoryStatus;
 import timify.com.member.domain.Member;
 
 @Entity
@@ -11,10 +10,10 @@ import timify.com.member.domain.Member;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class StudyPlace extends BaseDateTimeEntity {
+public class StudyType extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "study_place_id")
+    @Column(name = "study_type_id")
     private Long id;
 
     @Column(nullable = false, length = 30)
@@ -30,4 +29,14 @@ public class StudyPlace extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    // 연관관계 메소드
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getStudyTypeList().remove(this);
+        }
+        this.member = member;
+        this.member.getStudyTypeList().add(this);
+    }
+
 }

--- a/src/main/java/timify/com/study/dto/StudyRequest.java
+++ b/src/main/java/timify/com/study/dto/StudyRequest.java
@@ -1,0 +1,14 @@
+package timify.com.study.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+public class StudyRequest {
+    @Getter
+    public static class studyTypeInsertRequest {
+        @NotBlank
+        @Size(min = 1, max = 30)
+        String title;
+    }
+}

--- a/src/main/java/timify/com/study/dto/StudyRequest.java
+++ b/src/main/java/timify/com/study/dto/StudyRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 public class StudyRequest {
     @Getter
-    public static class studyTypeInsertRequest {
+    public static class studyTypeRequest {
         @NotBlank
         @Size(min = 1, max = 30)
         String title;

--- a/src/main/java/timify/com/study/dto/StudyResponse.java
+++ b/src/main/java/timify/com/study/dto/StudyResponse.java
@@ -1,0 +1,17 @@
+package timify.com.study.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StudyResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class studyTypeInsertDto {
+        Long studyTypeId;
+        String studyTypeTitle;
+    }
+}

--- a/src/main/java/timify/com/study/dto/StudyResponse.java
+++ b/src/main/java/timify/com/study/dto/StudyResponse.java
@@ -10,8 +10,9 @@ public class StudyResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class studyTypeInsertDto {
+    public static class studyTypeDto {
         Long studyTypeId;
         String studyTypeTitle;
     }
+
 }

--- a/src/main/java/timify/com/study/repository/StudyTypeRepository.java
+++ b/src/main/java/timify/com/study/repository/StudyTypeRepository.java
@@ -1,0 +1,13 @@
+package timify.com.study.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import timify.com.member.domain.Member;
+import timify.com.study.domain.CategoryStatus;
+import timify.com.study.domain.StudyType;
+
+import java.util.List;
+
+public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
+
+    List<StudyType> findAllByMemberAndStatus(Member member, CategoryStatus status);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,6 @@ springdoc:
 
 jwt:
   secret: ${JWT_SECRET}
-  access_expiration_time: 60000
+  access_expiration_time: 600000
   refresh_expiration_day: 31
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
공부 분류 조회 API 구현
공부 분류 수정 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Study 도메인을 별도 패키지로 분리하도록 파일 구조 변경
- 공부 분류 조회 API 추가
- 공부 분류 수정 API 추가
- jwt access token의 유효 시간을 10분으로 변경 (기존: 1분)

## ⏳ 작업 내용
- [x] 공부 분류 조회 API 구현
- [x] 공부 분류 수정 API 구현
- [x] Study 도메인 패키지 구조 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
