### PR TITLE
[Feature/31] 공부 장소 관련 API 구현

### DIFF
--- a/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/timify/com/common/apiPayload/code/status/ErrorStatus.java
@@ -37,7 +37,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_STUDY_TYPE_OWNER(HttpStatus.BAD_REQUEST, "STUDY4003", "해당 회원의 공부 분류가 아닙니다."),
     STUDY_METHOD_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4004", "이미 존재하는 공부 방법 이름 입니다."),
     STUDY_METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4005", "공부 방법을 찾을 수 없습니다."),
-    NOT_STUDY_METHOD_OWNER(HttpStatus.BAD_REQUEST, "STUDY4006", "해당 회원의 공부 방법이 아닙니다.");
+    NOT_STUDY_METHOD_OWNER(HttpStatus.BAD_REQUEST, "STUDY4006", "해당 회원의 공부 방법이 아닙니다."),
+    STUDY_PLACE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4007", "이미 존재하는 공부 방법 이름 입니다."),
+    STUDY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4008", "공부 방법을 찾을 수 없습니다."),
+    NOT_STUDY_PLACE_OWNER(HttpStatus.BAD_REQUEST, "STUDY4009", "해당 회원의 공부 방법이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -116,5 +116,17 @@ public class StudyController {
         return ApiResponse.onSuccess(StudyConverter.toStudyPlaceDto(studyPlace));
     }
 
+    @GetMapping("/place")
+    @Operation(summary = "공부 장소 조회 API", description = "공부 장소 목록을 조회하는 API 입니다.")
+    public ApiResponse<List<StudyResponse.studyPlaceDto>> getStudyPlace() {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+        List<StudyPlace> studyPlaceList = studyService.getStudyPlaces(member);
+        List<StudyResponse.studyPlaceDto> dtoList = studyPlaceList.stream()
+                .map(StudyConverter::toStudyPlaceDto)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(dtoList);
+    }
+
 
 }

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -13,6 +13,7 @@ import timify.com.common.apiPayload.ApiResponse;
 import timify.com.member.MemberService;
 import timify.com.member.domain.Member;
 import timify.com.study.domain.StudyMethod;
+import timify.com.study.domain.StudyPlace;
 import timify.com.study.domain.StudyType;
 import timify.com.study.dto.StudyRequest;
 import timify.com.study.dto.StudyResponse;
@@ -103,6 +104,16 @@ public class StudyController {
         StudyMethod studyMethod = studyService.updateStudyMethod(request, studyMethodId, member);
 
         return ApiResponse.onSuccess(StudyConverter.toStudyMethodDto(studyMethod));
+    }
+
+    @PostMapping("/place/insert")
+    @Operation(summary = "공부 장소 등록 API", description = "공부 장소를 추가하는 API 입니다.")
+    public ApiResponse<StudyResponse.studyPlaceDto> insertStudyPlace(@RequestBody @Valid StudyRequest.studyPlaceRequest request) {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+
+        StudyPlace studyPlace = studyService.insertStudyPlace(request, member);
+
+        return ApiResponse.onSuccess(StudyConverter.toStudyPlaceDto(studyPlace));
     }
 
 

--- a/src/main/java/timify/com/study/StudyController.java
+++ b/src/main/java/timify/com/study/StudyController.java
@@ -128,5 +128,20 @@ public class StudyController {
         return ApiResponse.onSuccess(dtoList);
     }
 
+    @PostMapping("/place/{studyPlaceId}/update")
+    @Operation(summary = "공부 장소 수정 API", description = "특정 공부 장소의 이름을 수정하는 API 입니다.")
+    @Parameters(value = {
+            @Parameter(name = "studyPlaceId", description = "공부 장소의 id 입니다.")
+    })
+    public ApiResponse<StudyResponse.studyPlaceDto> updateStudyPlace(
+            @RequestBody @Valid StudyRequest.studyPlaceRequest request,
+            @PathVariable(name = "studyPlaceId") Long studyPlaceId
+    ) {
+        Member member = memberService.findMember(SecurityUtil.getCurrentMemberId());
+        StudyPlace studyPlace = studyService.updateStudyPlace(request, studyPlaceId, member);
+
+        return ApiResponse.onSuccess(StudyConverter.toStudyPlaceDto(studyPlace));
+    }
+
 
 }

--- a/src/main/java/timify/com/study/StudyConverter.java
+++ b/src/main/java/timify/com/study/StudyConverter.java
@@ -2,6 +2,7 @@ package timify.com.study;
 
 import timify.com.study.domain.CategoryStatus;
 import timify.com.study.domain.StudyMethod;
+import timify.com.study.domain.StudyPlace;
 import timify.com.study.domain.StudyType;
 import timify.com.study.dto.StudyResponse;
 
@@ -33,6 +34,21 @@ public class StudyConverter {
         return StudyResponse.studyMethodDto.builder()
                 .studyMethodId(studyMethod.getId())
                 .studyMethodTitle(studyMethod.getTitle())
+                .build();
+    }
+
+    public static StudyPlace toStudyPlace(String title, int order) {
+        return StudyPlace.builder()
+                .title(title)
+                .orderNum(order)
+                .status(CategoryStatus.ACTIVE)
+                .build();
+    }
+
+    public static StudyResponse.studyPlaceDto toStudyPlaceDto(StudyPlace studyPlace) {
+        return StudyResponse.studyPlaceDto.builder()
+                .studyPlaceId(studyPlace.getId())
+                .studyPlaceTitle(studyPlace.getTitle())
                 .build();
     }
 }

--- a/src/main/java/timify/com/study/StudyConverter.java
+++ b/src/main/java/timify/com/study/StudyConverter.java
@@ -18,6 +18,7 @@ public class StudyConverter {
     public static StudyResponse.studyTypeDto toStudyTypeDto(StudyType studyType) {
         return StudyResponse.studyTypeDto.builder()
                 .studyTypeId(studyType.getId())
+                .order(studyType.getOrderNum())
                 .studyTypeTitle(studyType.getTitle())
                 .build();
     }
@@ -33,6 +34,7 @@ public class StudyConverter {
     public static StudyResponse.studyMethodDto toStudyMethodDto(StudyMethod studyMethod) {
         return StudyResponse.studyMethodDto.builder()
                 .studyMethodId(studyMethod.getId())
+                .order(studyMethod.getOrderNum())
                 .studyMethodTitle(studyMethod.getTitle())
                 .build();
     }
@@ -48,6 +50,7 @@ public class StudyConverter {
     public static StudyResponse.studyPlaceDto toStudyPlaceDto(StudyPlace studyPlace) {
         return StudyResponse.studyPlaceDto.builder()
                 .studyPlaceId(studyPlace.getId())
+                .order(studyPlace.getOrderNum())
                 .studyPlaceTitle(studyPlace.getTitle())
                 .build();
     }

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -133,4 +133,9 @@ public class StudyService {
         return studyPlaceRepository.save(studyPlace);
     }
 
+    @Transactional(readOnly = true)
+    public List<StudyPlace> getStudyPlaces(Member member) {
+        return studyPlaceRepository.findAllByMemberAndStatus(member, CategoryStatus.ACTIVE);
+    }
+
 }

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -138,4 +138,27 @@ public class StudyService {
         return studyPlaceRepository.findAllByMemberAndStatus(member, CategoryStatus.ACTIVE);
     }
 
+    @Transactional
+    public StudyPlace updateStudyPlace(StudyRequest.studyPlaceRequest request, Long studyPlaceId, Member member) {
+        StudyPlace studyPlace = studyPlaceRepository.findById(studyPlaceId).orElseThrow(() -> new StudyHandler(ErrorStatus.STUDY_PLACE_NOT_FOUND));
+
+        // 해당 studyPlace가 member의 것이 맞는지 검증
+        if (!studyPlace.getMember().equals(member)) {
+            throw new StudyHandler(ErrorStatus.NOT_STUDY_PLACE_OWNER);
+        }
+
+        // 활성화된 공부 징소와의 이름 중복 여부 검증
+        boolean exists = member.getStudyPlaceList().stream()
+                .anyMatch(place -> request.getTitle().equals(place.getTitle()) && place.getStatus().equals(CategoryStatus.ACTIVE));
+
+        if (exists) {
+            throw new StudyHandler(ErrorStatus.STUDY_PLACE_ALREADY_EXISTS);
+        }
+
+        // studyPlace의 이름 수정
+        studyPlace.setTitle(request.getTitle());
+
+        return studyPlace;
+    }
+
 }

--- a/src/main/java/timify/com/study/StudyService.java
+++ b/src/main/java/timify/com/study/StudyService.java
@@ -8,9 +8,11 @@ import timify.com.common.apiPayload.exception.handler.StudyHandler;
 import timify.com.member.domain.Member;
 import timify.com.study.domain.CategoryStatus;
 import timify.com.study.domain.StudyMethod;
+import timify.com.study.domain.StudyPlace;
 import timify.com.study.domain.StudyType;
 import timify.com.study.dto.StudyRequest;
 import timify.com.study.repository.StudyMethodRepository;
+import timify.com.study.repository.StudyPlaceRepository;
 import timify.com.study.repository.StudyTypeRepository;
 
 import java.util.List;
@@ -21,6 +23,7 @@ public class StudyService {
 
     private final StudyTypeRepository studyTypeRepository;
     private final StudyMethodRepository studyMethodRepository;
+    private final StudyPlaceRepository studyPlaceRepository;
 
     @Transactional
     public StudyType insertStudyType(StudyRequest.studyTypeRequest request, Member member) {
@@ -111,6 +114,23 @@ public class StudyService {
         studyMethod.setTitle(request.getTitle());
 
         return studyMethod;
+    }
+
+    @Transactional
+    public StudyPlace insertStudyPlace(StudyRequest.studyPlaceRequest request, Member member) {
+        // 이미 존재하는 이름의 StudyPlace인지 검증
+        boolean exists = member.getStudyPlaceList().stream()
+                .anyMatch(studyPlace -> request.getTitle().equals(studyPlace.getTitle()));
+
+        if (exists) {
+            throw new StudyHandler(ErrorStatus.STUDY_PLACE_ALREADY_EXISTS);
+        }
+
+        // StudyPlace 엔티티 생성 및 연관관계 매핑
+        StudyPlace studyPlace = StudyConverter.toStudyPlace(request.getTitle(), member.getStudyPlaceList().size() + 1);
+        studyPlace.setMember(member);
+
+        return studyPlaceRepository.save(studyPlace);
     }
 
 }

--- a/src/main/java/timify/com/study/domain/StudyPlace.java
+++ b/src/main/java/timify/com/study/domain/StudyPlace.java
@@ -38,4 +38,9 @@ public class StudyPlace extends BaseDateTimeEntity {
         this.member = member;
         this.member.getStudyPlaceList().add(this);
     }
+
+    // 장소 title 업데이트를 위한 메소드
+    public void setTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/timify/com/study/domain/StudyPlace.java
+++ b/src/main/java/timify/com/study/domain/StudyPlace.java
@@ -29,4 +29,13 @@ public class StudyPlace extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    // 연관관계 메소드
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getStudyPlaceList().remove(this);
+        }
+        this.member = member;
+        this.member.getStudyPlaceList().add(this);
+    }
 }

--- a/src/main/java/timify/com/study/dto/StudyRequest.java
+++ b/src/main/java/timify/com/study/dto/StudyRequest.java
@@ -18,4 +18,11 @@ public class StudyRequest {
         @Size(min = 1, max = 30)
         String title;
     }
+
+    @Getter
+    public static class studyPlaceRequest {
+        @NotBlank
+        @Size(min = 1, max = 30)
+        String title;
+    }
 }

--- a/src/main/java/timify/com/study/dto/StudyResponse.java
+++ b/src/main/java/timify/com/study/dto/StudyResponse.java
@@ -23,4 +23,13 @@ public class StudyResponse {
         Long studyMethodId;
         String studyMethodTitle;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class studyPlaceDto {
+        Long studyPlaceId;
+        String studyPlaceTitle;
+    }
 }

--- a/src/main/java/timify/com/study/dto/StudyResponse.java
+++ b/src/main/java/timify/com/study/dto/StudyResponse.java
@@ -12,6 +12,7 @@ public class StudyResponse {
     @AllArgsConstructor
     public static class studyTypeDto {
         Long studyTypeId;
+        Integer order;
         String studyTypeTitle;
     }
 
@@ -21,6 +22,7 @@ public class StudyResponse {
     @AllArgsConstructor
     public static class studyMethodDto {
         Long studyMethodId;
+        Integer order;
         String studyMethodTitle;
     }
 
@@ -30,6 +32,7 @@ public class StudyResponse {
     @AllArgsConstructor
     public static class studyPlaceDto {
         Long studyPlaceId;
+        Integer order;
         String studyPlaceTitle;
     }
 }

--- a/src/main/java/timify/com/study/repository/StudyPlaceRepository.java
+++ b/src/main/java/timify/com/study/repository/StudyPlaceRepository.java
@@ -1,7 +1,13 @@
 package timify.com.study.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import timify.com.member.domain.Member;
+import timify.com.study.domain.CategoryStatus;
 import timify.com.study.domain.StudyPlace;
 
+import java.util.List;
+
 public interface StudyPlaceRepository extends JpaRepository<StudyPlace, Long> {
+
+    List<StudyPlace> findAllByMemberAndStatus(Member member, CategoryStatus status);
 }

--- a/src/main/java/timify/com/study/repository/StudyPlaceRepository.java
+++ b/src/main/java/timify/com/study/repository/StudyPlaceRepository.java
@@ -1,0 +1,7 @@
+package timify.com.study.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import timify.com.study.domain.StudyPlace;
+
+public interface StudyPlaceRepository extends JpaRepository<StudyPlace, Long> {
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
공부 장소 등록/조회/수정 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 공부 장소 등록 API 추가
- 공부 장소 조회 API 추가
- 공부 장소 수정 API 추가
- 공부 분류/방법/장소 조회 API 응답에 order 데이터 추가

## ⏳ 작업 내용
- [x] 공부 장소 등록 API 구현
- [x] 공부 장소 조회 API 구현
- [x] 공부 장소 수정 API 구현
- [x] Validation
- [x] Swagger 명세

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
